### PR TITLE
Avoid a race condition when creating the tiles directory

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,4 @@
 pytest
 osmiter >= 1.1
+filelock
 typing_extensions

--- a/pyroutelib3/datastore.py
+++ b/pyroutelib3/datastore.py
@@ -116,11 +116,10 @@ class Datastore:
         filename = os.path.join(directory, "data.osm")
 
         # Make sure directory to which we download .osm files exists
-        if not os.path.exists(directory):
-            os.makedirs(directory)
+        os.makedirs(directory, exist_ok=True)
 
         # In versions prior to 1.0 tiles were saved to tilescache/z/x/y/data.osm.pkl
-        elif os.path.exists(filename + ".pkl"):
+        if os.path.exists(filename + ".pkl"):
             os.rename(filename + ".pkl", filename)
 
         # Don't redownload data from pre-expire date

--- a/pyroutelib3/datastore.py
+++ b/pyroutelib3/datastore.py
@@ -92,7 +92,14 @@ class Datastore:
 
         # Load the given osmfile
         if localfile is not None:
-            self.loadOsm(localfile, localfileType)
+            if isinstance(localfile, (list, tuple)):
+                if not isinstance(localfileType, (list, tuple)):
+                    localfileType = [localfileType] * len(localfile)
+
+                for onelocalfile, onelocalfileType in zip(localfile, localfileType):
+                    self.loadOsm(onelocalfile, onelocalfileType)
+            else:
+                self.loadOsm(localfile, localfileType)
 
     # Data Loading
 

--- a/pyroutelib3/datastore.py
+++ b/pyroutelib3/datastore.py
@@ -40,6 +40,11 @@ from .types import TYPES, TypeDescription, validate_type
 from .util import TILES_ZOOM, Position, DistFunction, distHaversine
 from .err import InvalidNode, OsmInvalidRestriction, OsmReferenceError, OsmStructureError
 
+API_SOURCES = {
+    "osm": "https://api.openstreetmap.org/api/0.6/",
+    "overpass": "https://www.overpass-api.de/api/xapi?",
+}
+
 
 class Datastore:
     # Graph data
@@ -68,13 +73,18 @@ class Datastore:
             localfileType: Literal['xml', 'gz', 'bz2', 'pbf'] = "xml",
             expireData: int = 30,
             ignoreDataErrs: bool = True,
-            distFunction: DistFunction = distHaversine) -> None:
+            distFunction: DistFunction = distHaversine,
+            source="osm") -> None:
         # Graph data
         self.rnodes = {}
         self.routing = {}
         self.mandatoryMoves = {}
         self.forbiddenMoves = {}
         self.distance = distFunction
+
+        if source not in API_SOURCES:
+            raise RuntimeError(f"Bad API source {source}")
+        self.source_baseurl = API_SOURCES[source]
 
         # Profile type
         if isinstance(transport, str):
@@ -139,7 +149,7 @@ class Datastore:
             left, bottom, right, top = getTileBoundary(x, y, TILES_ZOOM)
 
             urlretrieve(
-                f"https://api.openstreetmap.org/api/0.6/map?bbox={left},{bottom},{right},{top}",
+                f"{self.source_baseurl}map?bbox={left},{bottom},{right},{top}",
                 filename
             )
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
     ],
     packages=find_packages(include=["pyroutelib3", "pyroutelib3.*"]),
     python_requires=">=3.6, <4",
-    install_requires=["osmiter>=1.1", "typing_extensions"],
+    install_requires=["osmiter>=1.1", "filelock", "typing_extensions"],
     data_files=["LICENSE.txt", "README.md"],
 )


### PR DESCRIPTION
I recently encountered a race condition where `os.makedirs(directory)` would raise an except that the directory already exists. This PR avoids the race condition by passing `exist_ok=True` to `os.makedirs`.